### PR TITLE
Update session logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "eslint": "eslint ./src --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "prettier": "office-addin-lint prettier",
-    "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\""
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx}\"",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.4.2",

--- a/src/app/api/user/get-user-by-name/route.ts
+++ b/src/app/api/user/get-user-by-name/route.ts
@@ -3,7 +3,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import firebaseOperations from '@/services/firebase-service/firebase-operations';
 import { auth } from '@/services/firebase-service/firebase-admin';
 
-/* Buffer to return image to client */
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const { searchParams } = new URL(request.url);

--- a/src/app/api/user/logout/route.ts
+++ b/src/app/api/user/logout/route.ts
@@ -8,7 +8,7 @@ export async function POST(): Promise<Response> {
       status: 200,
       statusText: 'SUCCESS',
       headers: {
-        'Set-Cookie': `identity=; HttpOnly; Secure; Max-Age=86400; SameSite=Lax; Path=/`,
+        'Set-Cookie': `identity=; Max-Age=86400; SameSite=Lax; Path=/`,
       },
     });
   } catch (error) {

--- a/src/app/api/user/validate-user/route.ts
+++ b/src/app/api/user/validate-user/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request): Promise<Response> {
       status: 200,
       statusText: 'SUCCESS',
       headers: {
-        'Set-Cookie': `identity=${token}; HttpOnly; Secure; Max-Age=10000; SameSite=Lax; Path=/`,
+        'Set-Cookie': `identity=${token}; Max-Age=86400; SameSite=Lax; Path=/`,
       },
     });
   } catch (error) {

--- a/src/app/api/user/validate-user/route.ts
+++ b/src/app/api/user/validate-user/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request): Promise<Response> {
       status: 200,
       statusText: 'SUCCESS',
       headers: {
-        'Set-Cookie': `identity=${token}; HttpOnly; Secure; Max-Age=86400; SameSite=Lax; Path=/`,
+        'Set-Cookie': `identity=${token}; HttpOnly; Secure; Max-Age=10000; SameSite=Lax; Path=/`, // 86400
       },
     });
   } catch (error) {

--- a/src/app/api/user/validate-user/route.ts
+++ b/src/app/api/user/validate-user/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: Request): Promise<Response> {
       status: 200,
       statusText: 'SUCCESS',
       headers: {
-        'Set-Cookie': `identity=${token}; HttpOnly; Secure; Max-Age=10000; SameSite=Lax; Path=/`, // 86400
+        'Set-Cookie': `identity=${token}; HttpOnly; Secure; Max-Age=10000; SameSite=Lax; Path=/`,
       },
     });
   } catch (error) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -53,7 +53,6 @@
     }
     .mentions--multiLine .mentions__highlighter {
       padding: 8px;
-      color: var(--primary-foreground) !important;
       font-weight: 900;
     }
     .mentions--multiLine .mentions__input {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,20 @@
 'use client';
 
+import firebaseAuthService from '@/services/firebase-service/firebase-auth-service';
+
+import { useEffect } from 'react';
+
 const Home = (): React.ReactNode => {
+  useEffect(() => {
+    const handleCookieCheck = async (): Promise<void> => {
+      const cookie = document.cookie.replace(/(?:(?:^|.*;\s*)identity\s*=\s*([^;]*).*$)|^.*$/, '');
+      if (!document.cookie || cookie === '') {
+        await firebaseAuthService.signOut();
+      }
+    };
+    handleCookieCheck();
+  }, []);
+
   return <div>Home Page, show around 10 posts for the most active stocks of the day</div>;
 };
 

--- a/src/components/auth/login-with-provider.tsx
+++ b/src/components/auth/login-with-provider.tsx
@@ -20,11 +20,7 @@ export const LoginWithProviders = ({ isLoading }: LoginWithProvidersProps): Reac
         type='button'
         disabled={isLoading}
       >
-        {isLoading ? (
-          <Icons.spinner className='mr-2 h-4 w-4 animate-spin' />
-        ) : (
-          <Icons.google className='mr-2' />
-        )}
+        {isLoading ? <Icons.spinner className='mr-2 h-4 w-4 animate-spin' /> : <Icons.google />}
         Google ile devam et
       </Button>
     </div>

--- a/src/components/main-layout/main-layout.tsx
+++ b/src/components/main-layout/main-layout.tsx
@@ -25,10 +25,10 @@ import Discover from '@/components/doscover/discover';
 import useValidateSession from '@/hooks/useValidateSession';
 
 const MainLayout = ({ children }: { children: React.ReactNode }): React.ReactNode => {
+  useValidateSession();
   const dispatch = useDispatch();
   useUINotification();
   useUser();
-  useValidateSession();
 
   const isAuthModalOpen = useSelector(uiReducerSelector.getIsAuthModalOpen);
 

--- a/src/components/main-layout/main-layout.tsx
+++ b/src/components/main-layout/main-layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -22,12 +22,13 @@ import { AuthModal } from '@/components/auth/auth-modal';
 import uiReducerSelector from '@/store/reducers/ui-reducer/ui-reducer-selector';
 import { setIsAuthModalOpen } from '@/store/reducers/ui-reducer/ui-slice';
 import Discover from '@/components/doscover/discover';
+import useValidateSession from '@/hooks/useValidateSession';
 
 const MainLayout = ({ children }: { children: React.ReactNode }): React.ReactNode => {
   const dispatch = useDispatch();
-
   useUINotification();
   useUser();
+  useValidateSession();
 
   const isAuthModalOpen = useSelector(uiReducerSelector.getIsAuthModalOpen);
 

--- a/src/components/main-layout/main-layout.tsx
+++ b/src/components/main-layout/main-layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 

--- a/src/components/new-post/new-post.tsx
+++ b/src/components/new-post/new-post.tsx
@@ -36,8 +36,7 @@ const NewPost = (): React.ReactElement => {
   const mutation = useMutation({
     mutationFn: ({ post, postImageData }: { post: Post; postImageData: string }) =>
       postApiService.createNewPost(post, postImageData),
-    onSuccess: (data: any) => {
-      console.log('🚀 ~ NewPost ~ data:', data);
+    onSuccess: () => {
       dispatch(
         setUINotification({
           message: 'Gönnderi başarıyla oluşturuldu.',

--- a/src/components/new-post/new-post.tsx
+++ b/src/components/new-post/new-post.tsx
@@ -15,7 +15,6 @@ import { User } from '@/services/firebase-service/types/db-types/user';
 import { useDispatch, useSelector } from 'react-redux';
 import userReducerSelector from '@/store/reducers/user-reducer/user-reducer-selector';
 import { MediaData, Post } from '@/services/firebase-service/types/db-types/post';
-import { Timestamp } from 'firebase/firestore';
 import { useMutation } from '@tanstack/react-query';
 import { setUINotification, UINotificationEnum } from '@/store/reducers/ui-reducer/ui-slice';
 import { Icons } from '@/components/ui/icons';
@@ -37,7 +36,8 @@ const NewPost = (): React.ReactElement => {
   const mutation = useMutation({
     mutationFn: ({ post, postImageData }: { post: Post; postImageData: string }) =>
       postApiService.createNewPost(post, postImageData),
-    onSuccess: () => {
+    onSuccess: (data: any) => {
+      console.log('🚀 ~ NewPost ~ data:', data);
       dispatch(
         setUINotification({
           message: 'Gönnderi başarıyla oluşturuldu.',

--- a/src/components/post-editor/post-editor.tsx
+++ b/src/components/post-editor/post-editor.tsx
@@ -69,7 +69,7 @@ const PostEditor: React.FC<PostEditorProps> = ({ content, setContent, onSetCashT
     <MentionsInput
       autoFocus
       placeholder='$TUPRS - Ne düşünüyorsun?'
-      className='mentions resize-none	break-words break-all'
+      className='mentions resize-none break-words break-all'
       value={content}
       onChange={e => setContent(e.target.value)}
       maxLength={1000}

--- a/src/components/user-profile-options/user-profile-options.tsx
+++ b/src/components/user-profile-options/user-profile-options.tsx
@@ -45,7 +45,7 @@ const UserProfileOptions = (): React.ReactNode => {
   };
 
   return isAuthLoading ? (
-    <div className='flex items-center w-fit rounded-lg top-[60px] h-[170px] sticky shadow-lg'>
+    <div className='flex items-center rounded-lg w-[256px] top-[60px] h-[170px] sticky shadow-lg'>
       <Skeleton className='h-8 w-8 rounded-full' />
       <div className='space-y-2'>
         <Skeleton className='h-4 w-[150px]' />

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,9 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useDispatch, useSelector } from 'react-redux';
 
-import { onAuthStateChanged } from 'firebase/auth';
+import { onAuthStateChanged, User as FBAuthUserType } from 'firebase/auth';
 
 import { auth } from '@/services/firebase-service/firebase-config';
 
@@ -16,16 +16,17 @@ import { User } from '@/services/firebase-service/types/db-types/user';
 import userApiService from '@/services/api-service/user-api-service/user-api-service';
 import { Timestamp } from 'firebase/firestore';
 
-const useUser = (): UserState => {
+const useUser = (): { user: UserState; fbAuthUser: FBAuthUserType | null } => {
   const dispatch = useDispatch();
   const userState = useSelector(userReducerSelector.getUser);
+  const [fbAuthUser, setFBAuthUser] = useState<FBAuthUserType | null>(null);
 
   const router = useRouter();
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async user => {
       if (user) {
         const userData = (await userApiService.getUserById(user.uid)) as User;
-
+        setFBAuthUser(auth.currentUser);
         // register case
         if (!userData) {
           dispatch(setIsAuthModalOpen(false));
@@ -75,7 +76,7 @@ const useUser = (): UserState => {
     return () => unsubscribe();
   }, [dispatch, router, userState.username]);
 
-  return userState;
+  return { user: userState, fbAuthUser: fbAuthUser };
 };
 
 export default useUser;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -14,6 +14,7 @@ import userReducerSelector from '@/store/reducers/user-reducer/user-reducer-sele
 
 import { User } from '@/services/firebase-service/types/db-types/user';
 import userApiService from '@/services/api-service/user-api-service/user-api-service';
+import { Timestamp } from 'firebase/firestore';
 
 const useUser = (): UserState => {
   const dispatch = useDispatch();
@@ -34,7 +35,7 @@ const useUser = (): UserState => {
         // login case
         if (userData && !userState.username) {
           // Add more data if needed
-          const { displayName, username, email, profilePhoto, userId } = userData;
+          const { displayName, username, email, profilePhoto, userId, createdAt } = userData;
           dispatch(
             setUser({
               displayName,
@@ -42,6 +43,7 @@ const useUser = (): UserState => {
               email,
               profilePhoto,
               userId,
+              createdAt,
             })
           );
 
@@ -55,6 +57,7 @@ const useUser = (): UserState => {
             email: '',
             profilePhoto: '',
             userId: '',
+            createdAt: Timestamp.now(),
           })
         );
         await queryClient.fetchQuery({

--- a/src/hooks/useValidateSession.ts
+++ b/src/hooks/useValidateSession.ts
@@ -1,0 +1,32 @@
+import userApiService from '@/services/api-service/user-api-service/user-api-service';
+import { auth } from '@/services/firebase-service/firebase-config';
+import { useQuery } from '@tanstack/react-query';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { useEffect, useState } from 'react';
+
+const useValidateSession = (): void => {
+  const [user, setUser] = useState<User>();
+
+  const { refetch } = useQuery({
+    queryKey: ['validate-user'],
+    queryFn: () => userApiService.validateUser(user as User),
+    enabled: false,
+  });
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async fbUser => {
+      if (fbUser?.displayName) {
+        setUser(fbUser);
+      }
+    });
+    return () => unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (user?.email) {
+      refetch();
+    }
+  }, [user?.email, refetch]);
+};
+
+export default useValidateSession;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,12 +3,19 @@ import { NextResponse, NextRequest } from 'next/server';
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const cookie = request.headers.get('Cookie');
   const token = cookie?.split('identity=')[1];
+  const path = request.nextUrl.pathname;
 
   try {
     if (token) {
+      if (path === '/') {
+        return NextResponse.redirect(new URL('/feed', request.url));
+      }
       return NextResponse.next();
     } else {
-      return NextResponse.redirect(new URL('/', request.url));
+      if (path !== '/') {
+        return NextResponse.redirect(new URL('/', request.url));
+      }
+      return NextResponse.next();
     }
   } catch (error) {
     console.error('Authentication error:', error);
@@ -17,5 +24,5 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 }
 
 export const config = {
-  matcher: ['/feed/:path*', '/stocks/:path*', '/profile/:path*'],
+  matcher: ['/', '/feed/:path*', '/stocks/:path*', '/profile/:path*'],
 };


### PR DESCRIPTION
When the customly set cookie expires in the public api, middleware does not navigate to `/feed` paage and redirects back to `/`, even though user seems to be authenticated in the firebase. 

To prevent that, created a new hook that sends a request to `/validate-user` endpoint and extends the session in the api.

Added additional changes to fix `.ts` issues
Added typescript check with npm