### PR TITLE
Fix refreshing issue in post detail

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -111,6 +111,18 @@ const Home = (): React.ReactNode => {
   useEffect(() => {
     if (!fbAuthUser) return;
 
+    const postId = new URLSearchParams(window.location.search).get('post');
+
+    if (postId) {
+      (async () => {
+        const post = await postApiService.getPostById(postId);
+        if (post) {
+          setSelectedPost(post);
+          setActiveScreen(ActiveScreen.POST_DETAIL);
+        }
+      })();
+    }
+
     getMutation().mutate();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fbAuthUser]);


### PR DESCRIPTION
Currently, when user in the Post Detail page and clicks browser's refresh button it goes back to the Feed page. With this PR it will stay in the Post Detail page and link can be shared between users.