### PR TITLE
Fix image proxy 400 Bad Request errors

### DIFF
--- a/src/components/user-avatar/user-avatar.tsx
+++ b/src/components/user-avatar/user-avatar.tsx
@@ -8,7 +8,9 @@ interface UserAvatarProps {
 
 const UserAvatar: React.FC<UserAvatarProps> = ({ user, onUserAvatarClick }) => {
   const profileImage = user.profilePhoto;
-  const proxyUrl = `/api/image-proxy?imageUrl=${encodeURIComponent(profileImage as string)}`;
+  const proxyUrl = profileImage
+    ? `/api/image-proxy?imageUrl=${encodeURIComponent(profileImage)}`
+    : undefined;
 
   const initials = user.displayName
     ?.split(' ')
@@ -17,8 +19,13 @@ const UserAvatar: React.FC<UserAvatarProps> = ({ user, onUserAvatarClick }) => {
 
   return (
     <Avatar style={{ cursor: 'pointer' }} onClick={() => onUserAvatarClick?.()}>
-      <AvatarImage className='rounded-full' src={proxyUrl} alt='profile picture' />
-      <AvatarFallback className='relative p-2.5 bg-accent rounded-full'>{initials}</AvatarFallback>
+      {proxyUrl ? (
+        <AvatarImage className='rounded-full' src={proxyUrl} alt='profile picture' />
+      ) : (
+        <AvatarFallback className='relative p-2.5 bg-accent rounded-full'>
+          {initials}
+        </AvatarFallback>
+      )}
     </Avatar>
   );
 };


### PR DESCRIPTION
Ensure that image URLs are valid before making proxy requests to prevent 400 errors.

<img width="694" alt="Screenshot 2024-12-01 at 23 32 20" src="https://github.com/user-attachments/assets/c1bed77c-5a89-4cd3-8e8a-8712a664ab40">
