### PR TITLE
feat: Fix authentication issue with middleware

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,22 +1,9 @@
 'use client';
 
-import firebaseAuthService from '@/services/firebase-service/firebase-auth-service';
 import { useTranslations } from 'next-intl';
-
-import { useEffect } from 'react';
 
 const Home = (): React.ReactNode => {
   const t = useTranslations('HomePage');
-
-  useEffect(() => {
-    const handleCookieCheck = async (): Promise<void> => {
-      const cookie = document.cookie.replace(/(?:(?:^|.*;\s*)identity\s*=\s*([^;]*).*$)|^.*$/, '');
-      if (!document.cookie || cookie === '') {
-        await firebaseAuthService.signOut();
-      }
-    };
-    handleCookieCheck();
-  }, []);
 
   return <div>{t('title')}</div>;
 };

--- a/src/components/auth-wrapper/auth-wrapper.tsx
+++ b/src/components/auth-wrapper/auth-wrapper.tsx
@@ -1,3 +1,4 @@
+import firebaseAuthService from '@/services/firebase-service/firebase-auth-service';
 import { verifyUserAuthenticationForServerPage } from '@/services/user-service/user-service';
 import { User } from '@prisma/client';
 import { headers } from 'next/headers';
@@ -31,6 +32,7 @@ export function withAuthentication(
       // If the user is authenticated, proceed to the page
       return Page({ ...props, currentUser });
     } catch (error) {
+      await firebaseAuthService.signOut();
       return (
         <div>
           <meta httpEquiv='refresh' content={`0; url=${redirectUrl.toString()}`} />

--- a/src/components/auth-wrapper/auth-wrapper.tsx
+++ b/src/components/auth-wrapper/auth-wrapper.tsx
@@ -1,7 +1,6 @@
-import firebaseAuthService from '@/services/firebase-service/firebase-auth-service';
-import { verifyUserAuthenticationForServerPage } from '@/services/user-service/user-service';
-import { User } from '@prisma/client';
 import { headers } from 'next/headers';
+import { User } from '@prisma/client';
+import { verifyUserAuthenticationForServerPage } from '@/services/user-service/user-service';
 
 // Higher-order function to wrap pages with authentication
 export function withAuthentication(
@@ -32,7 +31,6 @@ export function withAuthentication(
       // If the user is authenticated, proceed to the page
       return Page({ ...props, currentUser });
     } catch (error) {
-      await firebaseAuthService.signOut();
       return (
         <div>
           <meta httpEquiv='refresh' content={`0; url=${redirectUrl.toString()}`} />

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -91,6 +91,10 @@ const useUser = (): { user: UserState; fbAuthUser: FBAuthUserType | null } => {
           queryKey: ['logOutUser'],
           queryFn: () => userApiService.logOutUser(),
         });
+
+        dispatch(setIsAuthModalOpen(false));
+        dispatch(setIsAuthLoading(false));
+
         router.push('/');
       }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -70,7 +70,7 @@ const handleAuth = (request: NextRequest): NextResponse | null => {
  * @type {NextMiddleware}
  */
 const middleware: NextMiddleware = (request: NextRequest): NextResponse | undefined => {
-  return handleI18n(request) || handleAuth(request) || NextResponse.next();
+  return handleI18n(request) || NextResponse.next();
 };
 
 export default middleware;


### PR DESCRIPTION
Middleware does not know when firebase token is expired and thus it navigates user to /feed. However, the newly added HOF that checks the fb token and since token is not valid, it logs out the user and navigates to landing page. This creates an infinite navigation between middleware and the HOF. 

It seems we dont need the authentication check in the middleware anymore. Thats why this pr removes the check for the authentication   